### PR TITLE
Use run/7 to skip unmodified .lfe files

### DIFF
--- a/src/lfe-compile.app.src
+++ b/src/lfe-compile.app.src
@@ -1,6 +1,6 @@
 {application, 'lfe-compile',
  [{description, "The LFE rebar3 compiler plugin"},
-  {vsn, "0.2.1"},
+  {vsn, "0.3.0"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/lfe-compile.erl
+++ b/src/lfe-compile.erl
@@ -1,41 +1,43 @@
 %% Copyright (c) 2009, Dave Smith <dizzyd@dizzyd.com> &
 %%                     Tim Dysinger <tim@dysinger.net>
 %% Copyright (c) 2014, 2015 Duncan McGreggor <oubiwann@gmail.com>
+%% Copyright (c) 2016 Eric Bailey <eric@ericb.me>
 %%
--module('lfe-compile').
--behaviour(provider).
 
--include("lr3_const.hrl").
+-module('lfe-compile').
+
+-behaviour(provider).
 
 -export([init/1,
          do/1,
          format_error/1]).
 
--define(NAMESPACE, lfe).
+-include("lr3_const.hrl").
+
 -define(DESC, "The LFE rebar3 compiler plugin").
 -define(DEPS, [{default, lock}]).
-
 
 %% ===================================================================
 %% Public API
 %% ===================================================================
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
     rebar_api:debug("Initializing {lfe, compile} ...", []),
-    Provider = providers:create([
-            {name, compile},
-            {module, ?MODULE},
-            {namespace, ?NAMESPACE},
-            {bare, true},
-            {deps, ?DEPS},
-            {example, "rebar3 lfe compile"},
-            {short_desc, ?DESC},
-            {desc, info(?DESC)},
-            {opts, []}
-    ]),
+    Provider = providers:create([{name,       ?PROVIDER},
+                                 {module,     ?MODULE},
+                                 {namespace,  ?NAMESPACE},
+                                 {bare,       true},
+                                 {deps,       ?DEPS},
+                                 {example,    "rebar3 lfe compile"},
+                                 {short_desc, ?DESC},
+                                 {desc,       info(?DESC)},
+                                 {opts,       []}]),
     State1 = rebar_state:add_provider(State, Provider),
     rebar_api:debug("Initialized {lfe, compile} ...", []),
     {ok, State1}.
 
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
     rebar_api:debug("Starting do/1 for {lfe, compile} ...", []),
     rebar_api:console(" ~~~~> \tFinding .lfe files ...",[]),
@@ -43,21 +45,24 @@ do(State) ->
                     [code:where_is_file("rebar_state.beam")]),
     lr3_comp:compile_normal_apps(State).
 
+-spec format_error(any()) -> iolist().
 format_error({missing_artifact, File}) ->
     io_lib:format("Missing artifact ~s", [File]);
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
+
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
 
+-spec info(string()) -> iolist().
 info(Description) ->
     io_lib:format(
-        "~n~s~n"
-        "~n"
-        "No additional configuration options are required to compile~n"
-        "LFE (*.lfe) files. The rebar 'erl_opts' setting is reused by~n"
-        "LFE. For more information, see the rebar documentation for~n"
-        "'erl_opts'.~n",
-        [Description]).
+      "~n~s~n"
+      "~n"
+      "No additional configuration options are required to compile~n"
+      "LFE (*.lfe) files. The rebar 'erl_opts' setting is reused by~n"
+      "LFE. For more information, see the rebar documentation for~n"
+      "'erl_opts'.~n",
+      [Description]).

--- a/src/lfe-compile.erl
+++ b/src/lfe-compile.erl
@@ -1,7 +1,7 @@
 %% Copyright (c) 2009, Dave Smith <dizzyd@dizzyd.com> &
 %%                     Tim Dysinger <tim@dysinger.net>
 %% Copyright (c) 2014, 2015 Duncan McGreggor <oubiwann@gmail.com>
-%% Copyright (c) 2016 Eric Bailey <eric@ericb.me>
+%% Copyright (c) 2016, Eric Bailey <eric@ericb.me>
 %%
 
 -module('lfe-compile').

--- a/src/lr3_comp.erl
+++ b/src/lr3_comp.erl
@@ -66,13 +66,16 @@ compile_normal_app(AppInfo) ->
     lr3_comp_util:copy_beam_files(AppInfo, OutDir),
     code:add_patha(lr3_comp_util:out_dir(rebar_app_info:dir(AppInfo))).
 
+-spec config(file:dirname(), list()) -> list().
 config(OutDir, ErlOpts) ->
     [{outdir, OutDir}] ++ ErlOpts ++
         [{i, lr3_comp_util:include_dir()}, return, verbose].
 
+-spec ensure_dir(file:dirname()) -> ok.
 ensure_dir(OutDir) ->
     %% Make sure that ebin/ exists and is on the path
     ok = filelib:ensure_dir(filename:join(OutDir, "dummy.beam")),
     AbsOutDir = filename:absname(OutDir),
     rebar_api:debug("\t\tAdding ~p to path ...", [AbsOutDir]),
-    true = code:add_patha(AbsOutDir).
+    true = code:add_patha(AbsOutDir),
+    ok.

--- a/src/lr3_comp.erl
+++ b/src/lr3_comp.erl
@@ -6,34 +6,21 @@
 
 -include("lr3_const.hrl").
 
--export([compile/4, compile/5,
+-export([compile/3,
+         compile_dir/4,
          compile_normal_apps/1]).
 
 %% ===================================================================
 %% Public API
 %% ===================================================================
 
-compile(State, Source, AppDir, OutDir) ->
-    rebar_api:debug("\t\tEntered compile/3 ...", []),
-    ErlOpts = rebar_opts:erl_opts(State),
-    compile(State, Source, AppDir, OutDir, ErlOpts).
-
-compile(_State, Source, _AppDir, OutDir, ErlOpts) ->
-    Target = lr3_comp_util:target_file(OutDir, Source),
-    rebar_api:debug("\t\tEntered compile/4 ...", []),
-    rebar_api:debug("\t\tSource: ~p~n\t\tOutDir: ~p", [Source, OutDir]),
-    rebar_api:debug("\t\tErlOpts: ~p", [ErlOpts]),
-    rebar_api:debug("\t\tTarget: ~p", [Target]),
-    %% Make sure that ebin/ exists and is on the path
-    ok = filelib:ensure_dir(filename:join(OutDir, "dummy.beam")),
-    AbsOutDir = filename:absname(OutDir),
-    rebar_api:debug("\t\tAdding ~p to path ...", [AbsOutDir]),
-    true = code:add_patha(AbsOutDir),
-    rebar_api:debug("\t\tCompiling~n\t\t\t~p~n\t\t\tto ~p ...", [Source, Target]),
-    Opts = [{outdir, OutDir}] ++ ErlOpts ++
-       [{i, lr3_comp_util:include_dir()}, return, verbose],
-    rebar_api:debug("\t\tOpts: ~p", [Opts]),
-    CompileResults = lfe_comp:file(Source, Opts),
+compile(Source, Target, Config) ->
+    rebar_api:console(" ~~~~> \tCompiling ~s ...",
+                      [lr3_comp_util:relative(Source)]),
+    rebar_api:debug("\t\tCompiling~n\t\t\t~p~n\t\t\tto ~p ...",
+                    [Source, Target]),
+    rebar_api:debug("\t\tConfig: ~p", [Config]),
+    CompileResults = lfe_comp:file(Source, Config),
     rebar_api:debug("\tCompile results: ~p", [CompileResults]),
     case CompileResults of
         {ok, _Mod} ->
@@ -41,8 +28,15 @@ compile(_State, Source, _AppDir, OutDir, ErlOpts) ->
         {ok, _Mod, Ws} ->
             rebar_base_compiler:ok_tuple(Source, Ws);
         {error, Es, Ws} ->
-            rebar_base_compiler:error_tuple(Source, Es, Ws, Opts)
+            rebar_base_compiler:error_tuple(Source, Es, Ws, Config)
     end.
+
+compile_dir(Config, FirstFiles, SourceDir, TargetDir) ->
+    ensure_dir(TargetDir),
+    SourceExt = ".lfe",
+    TargetExt = ".beam",
+    rebar_base_compiler:run(Config, FirstFiles, SourceDir, SourceExt, TargetDir,
+                            TargetExt, fun compile/3).
 
 compile_normal_apps(State) ->
     rebar_api:debug("\tCompiling normal LFE apps ...", []),
@@ -52,26 +46,33 @@ compile_normal_apps(State) ->
 
 compile_normal_app(AppInfo) ->
     lr3_comp_util:copy_app_src(AppInfo),
-    Opts = rebar_app_info:opts(AppInfo),
-    AppDir = rebar_app_info:dir(AppInfo),
+    Opts         = rebar_app_info:opts(AppInfo),
+    AppDir       = rebar_app_info:dir(AppInfo),
     OtherSrcDirs = rebar_dir:src_dirs(Opts),
+    SourceDirs   = lr3_comp_util:get_src_dirs(AppDir, ["src"] ++ OtherSrcDirs),
+    OutDir       = lr3_comp_util:relative_out_dir(AppInfo),
+    FirstFiles   = lr3_comp_util:get_first_files(Opts, AppDir),
+    ErlOpts      = rebar_opts:erl_opts(Opts),
+    Config       = config(OutDir, ErlOpts),
     rebar_api:debug("\tOtherSrcDirs: ~p", [OtherSrcDirs]),
-    SourceDirs = lr3_comp_util:get_src_dirs(AppDir, ["src"] ++ OtherSrcDirs),
-    %%OutDir = 'lfe-compiler-util':out_dir(AppDir),
-    OutDir = lr3_comp_util:relative_out_dir(AppInfo),
-    FirstFiles = lr3_comp_util:get_first_files(Opts, AppDir),
-    Files = lr3_comp_util:get_files(FirstFiles, SourceDirs),
     rebar_api:debug("\tAppInfoDir: ~p", [AppDir]),
     rebar_api:debug("\tSourceDirs: ~p", [SourceDirs]),
     rebar_api:debug("\tOutDir: ~p", [OutDir]),
     rebar_api:debug("\tFirstFiles: ~p", [FirstFiles]),
-    rebar_api:debug("\tFiles: ~p", [Files]),
-    DoCompile = fun(Source, Opts1) ->
-                  rebar_api:console(" ~~~~> \tCompiling ~s ...",
-                                    [lr3_comp_util:relative(Source)]),
-                  compile(Opts1, Source, AppDir, OutDir)
-                end,
-    rebar_base_compiler:run(Opts, [], Files, DoCompile),
+    rebar_api:debug("\tErlOpts: ~p", [ErlOpts]),
+    CompileDir = fun(Dir) -> compile_dir(Config, FirstFiles, Dir, OutDir) end,
+    lists:foreach(CompileDir, SourceDirs),
     rebar_api:debug("\tFinished compile.", []),
     lr3_comp_util:copy_beam_files(AppInfo, OutDir),
     code:add_patha(lr3_comp_util:out_dir(rebar_app_info:dir(AppInfo))).
+
+config(OutDir, ErlOpts) ->
+    [{outdir, OutDir}] ++ ErlOpts ++
+        [{i, lr3_comp_util:include_dir()}, return, verbose].
+
+ensure_dir(OutDir) ->
+    %% Make sure that ebin/ exists and is on the path
+    ok = filelib:ensure_dir(filename:join(OutDir, "dummy.beam")),
+    AbsOutDir = filename:absname(OutDir),
+    rebar_api:debug("\t\tAdding ~p to path ...", [AbsOutDir]),
+    true = code:add_patha(AbsOutDir).

--- a/src/lr3_comp.erl
+++ b/src/lr3_comp.erl
@@ -1,6 +1,7 @@
 %% Copyright (c) 2009, Dave Smith <dizzyd@dizzyd.com> &
 %%                     Tim Dysinger <tim@dysinger.net>
 %% Copyright (c) 2014, 2015 Duncan McGreggor <oubiwann@gmail.com>
+%% Copyright (c) 2016, Eric Bailey <eric@ericb.me>
 %%
 -module(lr3_comp).
 

--- a/src/lr3_comp_util.erl
+++ b/src/lr3_comp_util.erl
@@ -1,9 +1,11 @@
 -module(lr3_comp_util).
 
--export([copy_app_src/1,
+-export([config/2,
+         copy_app_src/1,
          copy_beam_files/2,
          out_dir/0, out_dir/1,
          include_dir/0, include_dir/1,
+         ensure_dir/1,
          get_apps/1,
          get_first_files/2,
          get_files/2,
@@ -12,6 +14,11 @@
          target_file/2,
          target_base/2,
          relative/1]).
+
+-spec config(file:dirname(), list()) -> list().
+config(OutDir, ErlOpts) ->
+    [{outdir, OutDir}] ++ ErlOpts ++
+        [{i, lr3_comp_util:include_dir()}, return, verbose].
 
 copy_app_src(AppInfo) ->
     rebar_api:debug("\t\tEntered copy_app_src/1 ...", []),
@@ -61,6 +68,15 @@ include_dir() ->
 
 include_dir(AppDir) ->
     filename:join(AppDir, "include").
+
+-spec ensure_dir(file:dirname()) -> ok.
+ensure_dir(OutDir) ->
+    %% Make sure that ebin/ exists and is on the path
+    ok = filelib:ensure_dir(filename:join(OutDir, "dummy.beam")),
+    AbsOutDir = filename:absname(OutDir),
+    rebar_api:debug("\t\tAdding ~p to path ...", [AbsOutDir]),
+    true = code:add_patha(AbsOutDir),
+    ok.
 
 get_apps(State) ->
     case rebar_state:current_app(State) of

--- a/src/lr3_const.hrl
+++ b/src/lr3_const.hrl
@@ -1,4 +1,5 @@
 -define(PROVIDER, compile).
+-define(NAMESPACE, lfe).
 -define(RE_PREFIX, "^[^._]").
 -define(PRV_ERROR(Reason),
         {error, {?MODULE, Reason}}).


### PR DESCRIPTION
This needs another set of eyes, but is working well for me locally.
I started a bigger refactor, but after a while I stopped and rolled back to this fairly minimal diff.
Since this is usually run as a `compile` post-hook, there's a lot that the erlc compiler has to do that we don't.
