### PR TITLE
Display compilation errors

### DIFF
--- a/src/lr3_comp.erl
+++ b/src/lr3_comp.erl
@@ -28,7 +28,7 @@ compile(Source, Target, Config) ->
             ok;
         {ok, _Mod, Ws} ->
             rebar_base_compiler:ok_tuple(Source, Ws);
-        {error, Es, Ws} ->
+        {error, [{error, Es, Ws}|_], _Es, _Ws} ->
             rebar_base_compiler:error_tuple(Source, Es, Ws, Config)
     end.
 


### PR DESCRIPTION
The lfe plugin doesn't properly display error messages. The reason is
that the pattern matching when lfe_comp:file fails wasn't working.

Match errors according to
https://github.com/rvirding/lfe/blob/develop/doc/lfe_comp.txt

I am not sure about what pattern matching is correct though as the current one will fail on an empty list and it will only take the first ModErr from the output.

Questions:
- Will there always be at least one ModErr when the error is returned?
- Can there ever be more than 1 when compiling 1 file at a time using lfe_comp:file(F, Opts)?
