### PR TITLE
Update for a better Hex release (0.4.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: erlang
+install: true
+env: PATH=".:$PATH"
+before_script:
+  - wget https://s3.amazonaws.com/rebar3/rebar3
+  - chmod +x rebar3
+script: rebar3 compile
+otp_release:
+  - 18.2
+  - 17.5
+  - R16B03-1
+  - R15B03

--- a/README.md
+++ b/README.md
@@ -50,18 +50,22 @@ $ rebar3 compile
 
 ## Use [&#x219F;](#contents)
 
-Add the plugin to your ``rebar.config``:
+To use this plugin, simply add it to your ``rebar.config``. This can be done in one of two ways (but not both!):
+
+For use with ``rebar3`` and Github repos:
 
 ```erlang
 {plugins, [
-   %% git:
    {'lfe-compile',
-    {git, "https://github.com/lfe-rebar3/compile.git", {tag, "0.4.0"}}}
+    {git, "https://github.com/lfe-rebar3/compile.git", {tag, "0.4.1"}}}
+ ]}.
+```
 
-   %% hex:
-   {lfe-compile, "0.4.3", {pkg, rebar3_lfe_compile}}
+For use with ``rebar3`` and hex.pm packages:
 
-   %% not both!
+```erlang
+{plugins, [
+   {lfe-compile, "0.4.1", {pkg, rebar3_lfe_compile}}
  ]}.
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,16 @@ one.
 
 Note that the LFE rebar3 plugins are not intended to be used as projects or
 tools in their own right -- they need to be incorporated into another project.
-You can add any LFE rebar3 plug to your project, of course, but the intend is
-for a new tool to wrap all of them. This tool is simply called
-[ltool](https://github.com/lfe-rebar3/ltool). The hope is that it will replace
-all the functionality that currently is built into lfetool.
+You can add any LFE rebar3 plugin to your project, of course, but the intent is
+for a new tool to wrap all of them. This tool is simply called [ltool][]. The
+hope is that it will replace all the functionality that currently is built into
+[lfetool][].
 
 If you would like to use this plugin in your own project, without a wrapping
-tool, see the "Use" section below.
+tool, see the [Use](#use-) section below.
+
+[ltool]: https://github.com/lfe-rebar3/ltool
+[lfetool]: https://github.com/lfex/lfetool
 
 ## Build [&#x219F;](#contents)
 
@@ -68,7 +71,7 @@ This will first download and build all your project dependencies, then compile
 all Erlang-related files your project may have, and finally it will compile the
 ``.lfe`` files in your project.
 
-If you would just like to to compile the ``.lfe`` files, you can use the
+If you would just like to compile the ``.lfe`` files, you can use the
 following command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For use with ``rebar3`` and hex.pm packages:
 
 ```erlang
 {plugins, [
-   {lfe-compile, "0.4.1", {pkg, rebar3_lfe_compile}}
+   {'lfe-compile', "0.4.1", {pkg, rebar3_lfe_compile}}
  ]}.
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,15 @@ Add the plugin to your ``rebar.config``:
 
 ```erlang
 {plugins, [
-  rebar3_lfe_compile
-]}.
+   %% git:
+   {'lfe-compile',
+    {git, "https://github.com/lfe-rebar3/compile.git", {tag, "0.4.0"}}}
+
+   %% hex:
+   {lfe-compile, "0.4.3", {pkg, rebar3_lfe_compile}}
+
+   %% not both!
+ ]}.
 ```
 
 Then let ``rebar3`` know that you want to call ``lfe compile`` after the

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # lfe-compile
 
 [![Hex.pm][hex badge]][hex package]
+[![Build Status][travis badge]][travis]
 
 [hex badge]: https://img.shields.io/hexpm/v/rebar3_lfe_compile.svg?maxAge=2592000
 [hex package]: https://hex.pm/packages/rebar3_lfe_compile
+[travis badge]: https://travis-ci.org/lfe-rebar3/compile.svg
+[travis]: https://travis-ci.org/lfe-rebar3/compile
 
 *The LFE rebar3 compiler plugin*
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # lfe-compile
 
+[![Hex.pm][hex badge]][hex package]
+
+[hex badge]: https://img.shields.io/hexpm/v/rebar3_lfe_compile.svg?maxAge=2592000
+[hex package]: https://hex.pm/packages/rebar3_lfe_compile
+
 *The LFE rebar3 compiler plugin*
 
 [lr3-logo]: resources/images/logo.png

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, []}.
 
 {deps, [
-  {lfe, "1.0.2"}
+  {lfe, {git, "https://github.com/rvirding/lfe.git", {tag, "v1.0.2"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, []}.
 
 {deps, [
-  {lfe, {git, "https://github.com/rvirding/lfe.git", {tag, "v1.0.2"}}}
+  {lfe, "1.0.2"}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,4 @@
-[{<<"lfe">>,{pkg,<<"lfe">>,<<"1.0.2">>},0}].
+[{<<"lfe">>,
+  {git,"https://github.com/rvirding/lfe.git",
+       {ref,"cd96efc3d2a73ecff7f3e2ef3563b73b098e4844"}},
+  0}].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,1 @@
-[{<<"lfe">>,
-  {git,"https://github.com/rvirding/lfe.git",
-       {ref,"cd96efc3d2a73ecff7f3e2ef3563b73b098e4844"}},
-  0}].
+[{<<"lfe">>,{pkg,<<"lfe">>,<<"1.0.2">>},0}].

--- a/src/lfe-compile.app.src
+++ b/src/lfe-compile.app.src
@@ -1,6 +1,6 @@
 {application, 'lfe-compile',
  [{description, "The LFE rebar3 compiler plugin"},
-  {vsn, "0.4.3"},
+  {vsn, "0.4.1"},
 
   {registered, []},
   {applications, [kernel, stdlib]},

--- a/src/lfe-compile.app.src
+++ b/src/lfe-compile.app.src
@@ -1,11 +1,14 @@
 {application, 'lfe-compile',
  [{description, "The LFE rebar3 compiler plugin"},
-  {vsn, "0.4.0"},
+  {vsn, "0.4.3"},
+
   {registered, []},
-  {applications,
-   [kernel,
-    stdlib
-   ]},
+  {applications, [kernel, stdlib]},
   {env,[]},
-  {modules, []}
+  {modules, []},
+
+  {pkg_name, rebar3_lfe_compile},
+  {maintainers, ["Duncan McGreggor", "Eric Bailey"]},
+  {licenses, ["BSD"]},
+  {links, [{"GitHub", "https://github.com/lfe-rebar3/compile"}]}
  ]}.


### PR DESCRIPTION
This PR now includes #18 and #19.

---

Use the [LFE Hex package](https://hex.pm/packages/lfe) since it has no dependencies/issues. There is no additional effort involved for users, since `rebar3` has a Hex dependency resolver internally.

Add `pkg_name` so we can keep `'lfe-compile'` without waiting for the Hex team to support (or decide not to support) hyphens:

``` erlang
{pkg_name, rebar3_lfe_compile}
```

~~Bump to [0.4.3](https://hex.pm/packages/rebar3_lfe_compile/0.4.3) to keep versioning sane wrt Hex.~~
