### PR TITLE
Add Hex badge and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,16 @@ one.
 
 Note that the LFE rebar3 plugins are not intended to be used as projects or
 tools in their own right -- they need to be incorporated into another project.
-You can add any LFE rebar3 plug to your project, of course, but the intend is
-for a new tool to wrap all of them. This tool is simply called
-[ltool](https://github.com/lfe-rebar3/ltool). The hope is that it will replace
-all the functionality that currently is built into lfetool.
+You can add any LFE rebar3 plugin to your project, of course, but the intent is
+for a new tool to wrap all of them. This tool is simply called [ltool][]. The
+hope is that it will replace all the functionality that currently is built into
+[lfetool][].
 
 If you would like to use this plugin in your own project, without a wrapping
-tool, see the "Use" section below.
+tool, see the [Use](#use-) section below.
+
+[ltool]: https://github.com/lfe-rebar3/ltool
+[lfetool]: https://github.com/lfex/lfetool
 
 ## Build [&#x219F;](#contents)
 
@@ -68,7 +71,7 @@ This will first download and build all your project dependencies, then compile
 all Erlang-related files your project may have, and finally it will compile the
 ``.lfe`` files in your project.
 
-If you would just like to to compile the ``.lfe`` files, you can use the
+If you would just like to compile the ``.lfe`` files, you can use the
 following command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -46,8 +46,15 @@ Add the plugin to your ``rebar.config``:
 
 ```erlang
 {plugins, [
-  rebar3_lfe_compile
-]}.
+   %% git:
+   {'lfe-compile',
+    {git, "https://github.com/lfe-rebar3/compile.git", {tag, "0.4.0"}}}
+
+   %% hex:
+   {lfe-compile, "0.4.3", {pkg, rebar3_lfe_compile}}
+
+   %% not both!
+ ]}.
 ```
 
 Then let ``rebar3`` know that you want to call ``lfe compile`` after the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # lfe-compile
 
+[![Hex.pm][hex badge]][hex package]
+
+[hex badge]: https://img.shields.io/hexpm/v/rebar3_lfe_compile.svg?maxAge=2592000
+[hex package]: https://hex.pm/packages/rebar3_lfe_compile
+
 *The LFE rebar3 compiler plugin*
 
 [lr3-logo]: resources/images/logo.png


### PR DESCRIPTION
#17 should be merged before this one.

---

Add the Hex badge (#16) and fix a few typos and add a few links.

Note that both `git` and Hex dependencies are mentioned in the updated [Use section](https://github.com/lfe-rebar3/compile/tree/feature/hex-badge#use-).
