### PR TITLE
Use LFE from hex

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
-%% By default, use Github
+%% By default, use Hex
 {deps, [
-  {lfe, {git, "https://github.com/rvirding/lfe.git", {tag, "v1.2.0"}}}
+  {lfe, "1.2.0"}
 ]}.
 
 {profiles, [


### PR DESCRIPTION
This enables us to use the rebar3 hex cache instead of cloning the LFE repo all the time.